### PR TITLE
Update making-money.zh.mdx

### DIFF
--- a/pages/making-money.zh.mdx
+++ b/pages/making-money.zh.mdx
@@ -28,10 +28,12 @@
 - 接入微信/支付宝（中国）
 - [微信小商店](https://shop.weixin.qq.com/)
 
-## 常见收费模式
+## 常见盈利模式
 
 - 基础功能免费，付费可用高级功能 ([feeds.pub](https://feeds.pub))
+- 额外云服务 ([vercel](https://vercel.com/))
 - 广告 ([star-history](https://star-history.com))
+- 课程分销 ([网易云课堂](https://study.163.com/course/introduction/1005954011.htm))
 - 收费应用 ([percento](https://www.percento.app/))
-- 进入社区付费 ([疯投圈](https://crazy.capital/))
+- 进入社区付费 ([疯投圈](https://crazy.capital/), [知识星球](https://zsxq.com/), [小鹅通](https://www.xiaoe-tech.com/))
 - 被收购 ([star-history](https://star-history.com))


### PR DESCRIPTION
hello，作者你好。很高兴可以看到一些特别 `sideproject` 的盈利模式。

以下是我的一些补充

- 额外云服务 ([vercel](https://vercel.com/))，[vercel](https://vercel.com/) 是依赖其开源的 [nextjs](https://nextjs.org/) 来做大量的用户增长的，后边就开始通过自己提供收费的云服务来盈利了。国内也有些类似的例子，例如 [dcloud](https://dcloud.io/) 依靠 [uniapp](https://uniapp.dcloud.io/) 也推出了 [unicloud](https://uniapp.dcloud.io/uniCloud/)，不过暂时还是免费的。
- 课程分销 ([网易云课堂](https://study.163.com/course/introduction/1005954011.htm))，很多程序员在见到优秀的 `sideproject` 时，都希望学习相关的内容，这时可以通过推广分销来引入第三方的优质内容以此达到盈利的目的。
- 进入社区付费 ([知识星球](https://zsxq.com/), [小鹅通](https://www.xiaoe-tech.com/)) 关于社区付费，国内比较出名的有 [知识星球](https://zsxq.com/) 和 [小鹅通](https://www.xiaoe-tech.com/) 这种偏 `sass` 的服务。